### PR TITLE
[chef] Move LLVM compilation into shell script, update protobuf version

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:12.04
 MAINTAINER Stefan Bucur <stefan.bucur@epfl.ch>
 
 # Tool dependencies
-RUN apt-get update && apt-get install -y build-essential subversion git gettext python-docutils python-pygments nasm unzip wget
+RUN apt-get update && apt-get install -y build-essential subversion git gettext python-docutils python-pygments nasm unzip wget realpath
 
 # Library dependencies
 RUN apt-get install -y liblua5.1-dev libsdl1.2-dev libsigc++-2.0-dev binutils-dev

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -23,40 +23,17 @@ RUN mkdir -p /build && cd /build &&\
   python scripts/mk_make.py && make -C build -j4 && make -C build install &&\
   rm -rf /build
 
+# Download & patch the LLVM source code
 ADD llvm-3.2-memorytracer.patch /opt/s2e/llvm/patches/
 ADD clang-3.2-memorytracer.patch /opt/s2e/llvm/patches/
 ADD compiler-rt-3.2-asan4s2e.patch /opt/s2e/llvm/patches/
+ADD buildllvm.sh /opt/s2e/llvm/patches/
 
-# Download & patch the LLVM source code
-RUN cd /opt/s2e/llvm &&\
-  wget 'http://llvm.org/releases/3.2/llvm-3.2.src.tar.gz' &&\
-  wget 'http://llvm.org/releases/3.2/clang-3.2.src.tar.gz' &&\
-  wget 'http://llvm.org/releases/3.2/compiler-rt-3.2.src.tar.gz' &&\
-  tar -xzvf llvm-3.2.src.tar.gz &&\
-  patch -d llvm-3.2.src -p0 -i ../patches/llvm-3.2-memorytracer.patch &&\
-  cp -r llvm-3.2.src llvm-3.2.src-native &&\
-  tar -xzvf clang-3.2.src.tar.gz &&\
-  patch -d clang-3.2.src -p0 -i ../patches/clang-3.2-memorytracer.patch && \
-  mv clang-3.2.src llvm-3.2.src-native/tools/clang &&\
-  tar -xzvf compiler-rt-3.2.src.tar.gz &&\
-  patch -d compiler-rt-3.2.src -p0 -i ../patches/compiler-rt-3.2-asan4s2e.patch && \
-  mv compiler-rt-3.2.src llvm-3.2.src-native/projects/compiler-rt &&\
-  rm -f *.src.tar.gz && rm -rf patches/
-
-# Build & install the native LLVM
-RUN cd /opt/s2e/llvm/llvm-3.2.src-native &&\
-  ./configure \
-    --prefix=/opt/s2e/llvm/llvm-3.2-native \
-    --enable-jit --enable-optimized --disable-assertions &&\
-  make ENABLE_OPTIMIZED=1 -j8 && make install && cd .. && rm -rf llvm-3.2.src-native
+RUN /opt/s2e/llvm/patches/buildllvm.sh fetch
 
 # Build the target LLVM
-RUN cd /opt/s2e/llvm && mkdir -p llvm-3.2.build && cd llvm-3.2.build &&\
-  ../llvm-3.2.src/configure \
-    --enable-jit --enable-optimized --target=x86_64 --enable-targets=x86 \
-    CC=/opt/s2e/llvm/llvm-3.2-native/bin/clang \
-    CXX=/opt/s2e/llvm/llvm-3.2-native/bin/clang++ &&\
-  make ENABLE_OPTIMIZED=1 REQUIRES_RTTI=1 -j8
+RUN /opt/s2e/llvm/patches/buildllvm.sh build release
+RUN /opt/s2e/llvm/patches/buildllvm.sh build debug
 
 # At this point we're left with three directories in /opt/s2e/llvm:
 # - llvm-3.2-native

--- a/image/base/buildllvm.sh
+++ b/image/base/buildllvm.sh
@@ -4,14 +4,12 @@
 # This script makes use of the `local' keyword. Although it is not POSIX
 # compliant, all shells on Linux (dash, ash, bash, zsh, ...) support it.
 
+runpath="$(realpath "$(dirname "$0")")"
+
 version=3.2
 baseurl="http://llvm.org/releases/$version"
 basedir=/opt/s2e/llvm
 prefix="$basedir/llvm-${version}-native"
-
-# XXX Ubuntu's coreutils does not ship the `realpath' command for some reason
-#runpath="$(realpath "$(dirname "$0")")"
-runpath="$basedir/patches"
 
 cores=1
 test -e /proc/cpuinfo && cores=$(grep -c '^processor' /proc/cpuinfo)

--- a/image/base/buildllvm.sh
+++ b/image/base/buildllvm.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env sh
+
+# WARNING!
+# This script makes use of the `local' keyword. Although it is not POSIX
+# compliant, all shells on Linux (dash, ash, bash, zsh, ...) support it.
+
+version=3.2
+baseurl="http://llvm.org/releases/$version"
+basedir=/opt/s2e/llvm
+prefix="$basedir/llvm-${version}-native"
+
+# XXX Ubuntu's coreutils does not ship the `realpath' command for some reason
+#runpath="$(realpath "$(dirname "$0")")"
+runpath="$basedir/patches"
+
+cores=1
+test -e /proc/cpuinfo && cores=$(grep -c '^processor' /proc/cpuinfo)
+
+# TODO: why is the patched LLVM called 'native'?
+
+# HELPERS ======================================================================
+
+die()
+{
+	retval=$1
+	shift
+	format="$1"
+	test -n "$format" && shift
+	printf "$(tput setaf 1)FATAL$(tput sgr0): ${format}\n" "$@" >&2
+	exit $retval
+}
+
+fxp()
+{
+	local prog="$1"
+	local vprog="$prog-$version"
+	local srcdir="${vprog}.src"
+	local srcball="${srcdir}.tar.gz"
+
+	# Fetch:
+	wget "$baseurl/$srcball"
+
+	# Extract:
+	tar -xzf "$srcball"
+
+	# Patch:
+	case "$prog" in
+		llvm|clang) local patchname=memorytracer;;
+		compiler-rt) local patchname=asan4s2e;;
+	esac
+	local patch="$runpath/$vprog-${patchname}.patch"
+	patch -d "$srcdir" -p0 -i "$patch"
+
+	# Clean up:
+	rm -f "$srcball"
+}
+
+# COMMAND: FETCH ===============================================================
+
+# Native LLVM is required to build the target LLVMs:
+buildnative()
+{
+	srcdir="$basedir/llvm-${version}.src-native"
+	builddir="$srcdir"
+
+	# Prepare source directory:
+	cp -r "llvm-${version}.src" "$srcdir"
+	fxp clang
+	mv "clang-${version}.src" "$srcdir/tools/clang"
+	fxp compiler-rt
+	mv "compiler-rt-${version}.src" "$srcdir/projects/compiler-rt"
+
+	# Prepare build directory:
+	mkdir -p "$builddir"
+	cd "$builddir"
+
+	# Build & install:
+	"$srcdir/configure" \
+	    --prefix="$prefix" \
+	    --enable-jit \
+	    --enable-optimized \
+	    --disable-assertions
+	make ENABLE_OPTIMIZED=1 -j$cores
+	make install
+
+	# Clean up:
+	cd "$basedir"
+	rm -rf "$srcdir" "$builddir"
+}
+
+fetch()
+{
+	# Get LLVM:
+	cd "${basedir}"
+	fxp llvm
+
+	# Build and install native LLVM:
+	buildnative
+}
+
+# COMMAND: BUILD ===============================================================
+
+build_usage()
+{
+	cat <<- EOF
+
+	$0 build: Build LLVM in a given mode
+
+	Usage: $0 build MODE
+
+	Modes:
+	    release   Build LLVM in Release mode (=> Release+Asserts)
+	    debug     Build LLVM in Debug mode (=> Debug+Asserts)
+
+	EOF
+	exit 1
+}
+
+build()
+{
+	srcdir="$basedir/llvm-${version}.src"
+	builddir="$basedir/llvm-${version}.build"
+
+	# Build mode:
+	mode="$1"
+	test -n "$mode" || build_usage
+	shift
+	case "$mode" in
+	release)
+		copt='--enable-optimized'
+		mopt=1
+		;;
+	debug)
+		copt='--disable-optimized'
+		mopt=0
+		;;
+	*)
+		build_usage
+		;;
+	esac
+
+	# Prepare build directory:
+	mkdir -p "$builddir"
+	cd "$builddir"
+
+	# Configure & build:
+	"$srcdir/configure" \
+	    --enable-jit \
+	    --target=x86_64 \
+	    --enable-targets=x86 \
+	    $copt \
+	    CC="$prefix/bin/clang" \
+	    CXX="$prefix/bin/clang++"
+	make ENABLE_OPTIMIZED=$mopt REQUIRES_RTTI=1 -j$cores
+}
+
+# MAIN =========================================================================
+
+usage()
+{
+	cat <<- EOF
+
+	$0: Download and build LLVM for the S²E base image
+
+	Usage: $0 COMMAND [ARGS ...]
+
+	Commands:
+	    fetch    Fetch the LLVM source, build and install native LLVM
+	    build    Build target LLVM
+
+	EOF
+	exit 1
+}
+
+main()
+{
+	cmd="$1"
+	test -n "$cmd" || usage
+	shift
+	set -e
+	case "$cmd" in
+		fetch) fetch "$@";;
+		build) build "$@";;
+		*) usage;;
+	esac
+	set +e
+}
+
+main "$@"

--- a/image/chef/Dockerfile
+++ b/image/chef/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get install -y libdwarf-dev libelf-dev libboost-dev \
 
 # Install protobuf
 RUN mkdir -p /build &&\
-  wget 'https://protobuf.googlecode.com/svn/rc/protobuf-2.5.0.tar.gz' &&\
-  tar xzvf protobuf-2.5.0.tar.gz &&\
-  cd protobuf-2.5.0 && ./configure && make -j8 && make install && ldconfig &&\
+  wget 'https://protobuf.googlecode.com/svn/rc/protobuf-2.6.0.tar.gz' &&\
+  tar xzvf protobuf-2.6.0.tar.gz &&\
+  cd protobuf-2.6.0 && ./configure && make -j8 && make install && ldconfig &&\
   rm -rf /build
 
 RUN mkdir -p /home/s2e


### PR DESCRIPTION
The Dockerfile currently invokes the compilation of both the debug version _and_ the release version of chef. Depending on the needs, this may need to be split up.

Further changes:
- Correctly download protobuf 2.6.0 to satisfy chef's requirements
- Additionally install the `realpath` package, as the `buildllvm.sh` script requires it to run correctly (on Debian/Ubuntu, the command has somehow been moved out of the coreutils install, I have no clue why).
